### PR TITLE
Cleanup and specs

### DIFF
--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -8,7 +8,6 @@ module RocketJobMissionControl
 
       respond_to do |format|
         format.html { redirect_to job_path(@job) }
-        format.js
       end
     end
 
@@ -17,7 +16,6 @@ module RocketJobMissionControl
 
       respond_to do |format|
         format.html { redirect_to job_path(@job) }
-        format.js
       end
     end
 
@@ -27,7 +25,6 @@ module RocketJobMissionControl
 
       respond_to do |format|
         format.html
-        format.js { render :index }
       end
     end
 
@@ -36,7 +33,6 @@ module RocketJobMissionControl
 
       respond_to do |format|
         format.html
-        format.js
       end
     end
 

--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -22,7 +22,7 @@ module RocketJobMissionControl
     end
 
     def show
-      @jobs = RocketJob::Job.sort(priority: :desc, created_at: :desc)
+      @jobs = RocketJob::Job.sort(created_at: :desc)
       @job = RocketJob::Job.find(params[:id])
 
       respond_to do |format|
@@ -32,7 +32,7 @@ module RocketJobMissionControl
     end
 
     def index
-      @jobs = RocketJob::Job.sort(priority: :desc, created_at: :desc)
+      @jobs = RocketJob::Job.sort(created_at: :desc)
 
       respond_to do |format|
         format.html

--- a/app/helpers/rocket_job_mission_control/jobs_helper.rb
+++ b/app/helpers/rocket_job_mission_control/jobs_helper.rb
@@ -31,5 +31,17 @@ module RocketJobMissionControl
         ""
       end
     end
+
+    def job_duration(job)
+      started_at = job.status[:started_at]
+      time_to    = if job.completed?
+                     job.status[:completed_at]
+                   elsif job.aborted?
+                     job.status[:aborted_at]
+                   else
+                     Time.now
+                   end
+      distance_of_time_in_words(started_at, time_to, highest_measure_only: true, include_seconds: true)
+    end
   end
 end

--- a/app/helpers/rocket_job_mission_control/jobs_helper.rb
+++ b/app/helpers/rocket_job_mission_control/jobs_helper.rb
@@ -1,5 +1,20 @@
 module RocketJobMissionControl
   module JobsHelper
+    def job_state_icon(state)
+      case state
+      when :queued
+        'fa-bed warning'
+      when :running
+        'fa-cog fa-spin primary'
+      when :completed
+        'fa-check-circle-o success'
+      when :aborted
+        'fa-times-circle-o warning'
+      else
+        'fa-times-circle-o danger'
+      end
+    end
+
     def job_class(job)
       case job.state
       when :queued

--- a/app/views/rocket_job_mission_control/jobs/_list.html.haml
+++ b/app/views/rocket_job_mission_control/jobs/_list.html.haml
@@ -15,17 +15,7 @@
 
           .title.float-left
             %h3
-              - case job.state
-              - when :queued
-                %i.fa.fa-bed.warning
-              - when :running
-                %i.fa.fa-cog.fa-spin.primary
-              - when :completed
-                %i.fa.fa-check-circle-o.success
-              - when :aborted
-                %i.fa.fa-times-circle-o.warning
-              - else :failed
-                %i.fa.fa-times-circle-o.danger
+              %i.fa{class: job_state_icon(job.state)}
 
               = "#{job.priority} - #{job.klass}##{job.perform_method}"
 

--- a/app/views/rocket_job_mission_control/jobs/_list.html.haml
+++ b/app/views/rocket_job_mission_control/jobs/_list.html.haml
@@ -20,20 +20,10 @@
               = "#{job.priority} - #{job.klass}##{job.perform_method}"
 
           .duration
-            - case job.state
-            - when :queued
-              %i.fa.fa-clock-o
-              = distance_of_time_in_words_to_now(job.status[:started_at], include_seconds: true)
-              queued
-            - when :completed
-              %i.fa.fa-clock-o
-              = distance_of_time_in_words(job.status[:started_at], job.status[:completed_at], include_seconds: true)
-            - when :running
-              %i.fa.fa-clock-o
-              = distance_of_time_in_words_to_now(job.status[:started_at], include_seconds: true)
-            - when :aborted
-              %i.fa.fa-clock-o
-              = distance_of_time_in_words(job.status[:started_at], job.status[:aborted_at], include_seconds: true)
-            - when :failed
+            - if job.failed?
               %i.fa.fa-bomb
               failed
+            - else
+              %i.fa.fa-clock-o
+              = job_duration(job)
+

--- a/app/views/rocket_job_mission_control/jobs/_list.html.haml
+++ b/app/views/rocket_job_mission_control/jobs/_list.html.haml
@@ -7,7 +7,7 @@
 
   .list
     - @jobs.each do |job|
-      = link_to job_path(id: job.id), remote: true, class: 'card' do
+      = link_to job_path(id: job.id), class: 'card' do
         .inner
           - if job._type == "RocketJob::SlicedJob" && job.input.queued_slices > 0
             .batch

--- a/app/views/rocket_job_mission_control/jobs/_status.html.haml
+++ b/app/views/rocket_job_mission_control/jobs/_status.html.haml
@@ -27,12 +27,19 @@
 
 .clearfix
 
-.description
-  %b Created At:
+.id
+  %label ID:
+  = @job.id
+.created_at
+  %label Created At:
   = @job.created_at
 
 - @job.status.each_pair do |key, value|
   .status-message
-    %b= key.to_s.titleize
+    %label= "#{key.to_s.titleize}:"
     = value
 .clearfix
+
+.parameters
+  %label Parameters:
+  %div= @job.arguments

--- a/app/views/rocket_job_mission_control/jobs/index.js.erb
+++ b/app/views/rocket_job_mission_control/jobs/index.js.erb
@@ -1,1 +1,0 @@
-$("#job").html("<%= escape_javascript(render partial: 'status', locals: { job: @job } ) %>");

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -23,6 +23,10 @@ module RocketJobMissionControl
         it "assigns the jobs" do
           expect(assigns(:jobs)).to eq([])
         end
+
+        it "grabs a sorted list of rocket jobs" do
+          expect(RocketJob::Job).to have_received(:sort).with(created_at: :desc)
+        end
       end
     end
 
@@ -36,6 +40,11 @@ module RocketJobMissionControl
         it "succeeds" do
           expect(response.status).to be(200)
         end
+
+        it "grabs a sorted list of rocket jobs" do
+          expect(RocketJob::Job).to have_received(:sort).with(created_at: :desc)
+        end
+
         it "returns no jobs" do
           expect(assigns(:jobs)).to eq([])
         end
@@ -52,6 +61,11 @@ module RocketJobMissionControl
         it "succeeds" do
           expect(response.status).to be(200)
         end
+
+        it "grabs a sorted list of rocket jobs" do
+          expect(RocketJob::Job).to have_received(:sort).with(created_at: :desc)
+        end
+
         it "returns the jobs" do
           expect(assigns(:jobs)).to match_array(jobs)
         end

--- a/spec/helpers/jobs_helper_spec.rb
+++ b/spec/helpers/jobs_helper_spec.rb
@@ -2,15 +2,32 @@ require 'rails_helper'
 
 module RocketJobMissionControl
   RSpec.describe JobsHelper, type: :helper do
+    describe "#job_state_icon" do
+      {
+        queued:     'fa-bed warning',
+        running:    'fa-cog fa-spin primary',
+        completed:  'fa-check-circle-o success',
+        aborted:    'fa-times-circle-o warning',
+        unexpected: 'fa-times-circle-o danger'
+      }.each do |state, expected_class|
+        context "when the job state is #{state}" do
+          it "returns the correct class" do
+            expect(helper.job_state_icon(state)).to eq(expected_class)
+          end
+        end
+      end
+    end
+
     describe "#job_class" do
       let(:job) { double(:job, state: job_state) }
 
       {
-        queued:    "warning",
-        running:   "primary",
-        completed: "success",
-        aborted:   "warning",
-        failed:    "danger",
+        queued:     "warning",
+        running:    "primary",
+        completed:  "success",
+        aborted:    "warning",
+        failed:     "danger",
+        unexpected: "",
       }.each do |state, expected_class|
         context "when job state is #{state}" do
           let(:job_state) { state }

--- a/spec/helpers/jobs_helper_spec.rb
+++ b/spec/helpers/jobs_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+module RocketJobMissionControl
+  RSpec.describe JobsHelper, type: :helper do
+    describe "#job_class" do
+      let(:job) { double(:job, state: job_state) }
+
+      {
+        queued:    "warning",
+        running:   "primary",
+        completed: "success",
+        aborted:   "warning",
+        failed:    "danger",
+      }.each do |state, expected_class|
+        context "when job state is #{state}" do
+          let(:job_state) { state }
+
+          it "returns the correct class" do
+            expect(helper.job_class(job)).to eq(expected_class)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/jobs_helper_spec.rb
+++ b/spec/helpers/jobs_helper_spec.rb
@@ -2,6 +2,39 @@ require 'rails_helper'
 
 module RocketJobMissionControl
   RSpec.describe JobsHelper, type: :helper do
+    #TODO: Timecop this for stability
+    describe "#job_duration" do
+      let(:job) { double(:job, status: status, completed?: false, aborted?: false) }
+
+      context "when the job is completed" do
+        let(:status) { {started_at: Time.now, completed_at: 1.minute.from_now} }
+
+        before { allow(job).to receive(:completed?).and_return(true) }
+
+        it "returns the time between started at and completed at" do
+          expect(helper.job_duration(job)).to eq('1 minute')
+        end
+      end
+
+      context "when the job is aborted" do
+        let(:status) { {started_at: Time.now, aborted_at: 2.minutes.from_now} }
+
+        before { allow(job).to receive(:aborted?).and_return(true) }
+
+        it "returns the time between started at and aborted at" do
+          expect(helper.job_duration(job)).to eq('2 minutes')
+        end
+      end
+
+      context "when the job is not aborted or complated" do
+        let(:status) { {started_at: Time.now} }
+
+        it "returns the time between started at and now" do
+          expect(helper.job_duration(job)).to eq('5 seconds')
+        end
+      end
+    end
+
     describe "#job_state_icon" do
       {
         queued:     'fa-bed warning',
@@ -10,11 +43,13 @@ module RocketJobMissionControl
         aborted:    'fa-times-circle-o warning',
         unexpected: 'fa-times-circle-o danger'
       }.each do |state, expected_class|
+
         context "when the job state is #{state}" do
           it "returns the correct class" do
             expect(helper.job_state_icon(state)).to eq(expected_class)
           end
         end
+
       end
     end
 
@@ -35,6 +70,7 @@ module RocketJobMissionControl
           it "returns the correct class" do
             expect(helper.job_class(job)).to eq(expected_class)
           end
+
         end
       end
     end


### PR DESCRIPTION
* Move some view logic to helpers for reuse and testability
* Remove ajax render of the JobsController#show action
* Only order jobs results by created_at
* Return a shorter duration description