### PR TITLE
Speed up job index page load

### DIFF
--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -21,12 +21,12 @@ module RocketJobMissionControl
     end
 
     def show
-      @jobs = RocketJob::Job.limit(100).sort(created_at: :desc)
+      @jobs = RocketJob::Job.limit(1000).sort(created_at: :desc)
       @job = RocketJob::Job.find(params[:id])
     end
 
     def index
-      @jobs = RocketJob::Job.limit(100).sort(created_at: :desc)
+      @jobs = RocketJob::Job.limit(1000).sort(created_at: :desc)
     end
 
     private

--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -21,12 +21,12 @@ module RocketJobMissionControl
     end
 
     def show
-      @jobs = RocketJob::Job.sort(created_at: :desc)
+      @jobs = RocketJob::Job.limit(100).sort(created_at: :desc)
       @job = RocketJob::Job.find(params[:id])
     end
 
     def index
-      @jobs = RocketJob::Job.sort(created_at: :desc)
+      @jobs = RocketJob::Job.limit(100).sort(created_at: :desc)
     end
 
     private

--- a/app/helpers/rocket_job_mission_control/jobs_helper.rb
+++ b/app/helpers/rocket_job_mission_control/jobs_helper.rb
@@ -31,11 +31,11 @@ module RocketJobMissionControl
     end
 
     def job_duration(job)
-      started_at = job.status[:started_at]
+      started_at = job.started_at
       time_to    = if job.completed?
-                     job.status[:completed_at]
+                     job.completed_at
                    elsif job.aborted?
-                     job.status[:aborted_at]
+                     job.completed_at
                    else
                      Time.now
                    end

--- a/app/views/rocket_job_mission_control/jobs/_list.html.haml
+++ b/app/views/rocket_job_mission_control/jobs/_list.html.haml
@@ -9,10 +9,6 @@
     - @jobs.each do |job|
       = link_to job_path(id: job.id), class: 'card' do
         .inner
-          - if job._type == "RocketJob::SlicedJob" && job.input.queued_slices > 0
-            .batch
-              = job.input.queued_slices
-
           .title.float-left
             %h3
               %i.fa{class: job_state_icon(job.state)}

--- a/spec/controllers/jobs_controller_spec.rb
+++ b/spec/controllers/jobs_controller_spec.rb
@@ -44,8 +44,10 @@ module RocketJobMissionControl
 
     describe "GET #show" do
       describe "with a valid job id" do
+        let(:result) { spy(sort: []) }
+
         before do
-          allow(RocketJob::Job).to receive(:sort).and_return([])
+          allow(RocketJob::Job).to receive(:limit).and_return(result)
           allow(RocketJob::Job).to receive(:find).and_return('job')
           get :show, id: 42
         end
@@ -63,15 +65,17 @@ module RocketJobMissionControl
         end
 
         it "grabs a sorted list of rocket jobs" do
-          expect(RocketJob::Job).to have_received(:sort).with(created_at: :desc)
+          expect(result).to have_received(:sort).with(created_at: :desc)
         end
       end
     end
 
     describe "GET #index" do
       describe "with no jobs" do
+        let(:result) { spy(sort: []) }
+
         before do
-          allow(RocketJob::Job).to receive(:sort).and_return([])
+          allow(RocketJob::Job).to receive(:limit).and_return(result)
           get :index
         end
 
@@ -80,7 +84,7 @@ module RocketJobMissionControl
         end
 
         it "grabs a sorted list of rocket jobs" do
-          expect(RocketJob::Job).to have_received(:sort).with(created_at: :desc)
+          expect(result).to have_received(:sort).with(created_at: :desc)
         end
 
         it "returns no jobs" do
@@ -89,10 +93,11 @@ module RocketJobMissionControl
       end
 
       describe "with jobs" do
+        let(:result) { spy(sort: jobs) }
         let(:jobs) { ['fake_job1', 'fake_job2'] }
 
         before do
-          allow(RocketJob::Job).to receive(:sort).and_return(jobs)
+          allow(RocketJob::Job).to receive(:limit).and_return(result)
           get :index
         end
 
@@ -101,7 +106,7 @@ module RocketJobMissionControl
         end
 
         it "grabs a sorted list of rocket jobs" do
-          expect(RocketJob::Job).to have_received(:sort).with(created_at: :desc)
+          expect(result).to have_received(:sort).with(created_at: :desc)
         end
 
         it "returns the jobs" do

--- a/spec/helpers/jobs_helper_spec.rb
+++ b/spec/helpers/jobs_helper_spec.rb
@@ -4,12 +4,13 @@ module RocketJobMissionControl
   RSpec.describe JobsHelper, type: :helper do
     #TODO: Timecop this for stability
     describe "#job_duration" do
-      let(:job) { double(:job, status: status, completed?: false, aborted?: false) }
+      let(:job) { double(:job, completed?: false, aborted?: false, started_at: Time.now) }
 
       context "when the job is completed" do
-        let(:status) { {started_at: Time.now, completed_at: 1.minute.from_now} }
-
-        before { allow(job).to receive(:completed?).and_return(true) }
+        before do
+          allow(job).to receive(:completed?).and_return(true)
+          allow(job).to receive(:completed_at).and_return(1.minute.from_now)
+        end
 
         it "returns the time between started at and completed at" do
           expect(helper.job_duration(job)).to eq('1 minute')
@@ -17,17 +18,20 @@ module RocketJobMissionControl
       end
 
       context "when the job is aborted" do
-        let(:status) { {started_at: Time.now, aborted_at: 2.minutes.from_now} }
-
-        before { allow(job).to receive(:aborted?).and_return(true) }
+        before do
+          allow(job).to receive(:aborted?).and_return(true)
+          allow(job).to receive(:completed_at).and_return(2.minutes.from_now)
+        end
 
         it "returns the time between started at and aborted at" do
           expect(helper.job_duration(job)).to eq('2 minutes')
         end
       end
 
-      context "when the job is not aborted or complated" do
-        let(:status) { {started_at: Time.now} }
+      context "when the job is not aborted or completed" do
+        before do
+          allow(job).to receive(:started_at).and_return(Time.now)
+        end
 
         it "returns the time between started at and now" do
           expect(helper.job_duration(job)).to eq('5 seconds')


### PR DESCRIPTION
* No longer show the number of queued slices for large jobs
* Limit the index to the latest 1000 jobs
* Do not call `status` on the job when checking the duration